### PR TITLE
Fix CycleType in seed file

### DIFF
--- a/lib/tasks/seed_tasks.rake
+++ b/lib/tasks/seed_tasks.rake
@@ -30,10 +30,9 @@ task seed_test_users_and_bikes: :environment do
   @user = User.find_by_email('user@example.com')
   @member = User.find_by_email('member@example.com')
   @org = Organization.first
-  @cycle_type_id = CycleType.find_by_name('Bike').id
   50.times do
     bike = Bike.new(
-      cycle_type_id: @cycle_type_id,
+      cycle_type: :bike,
       propulsion_type: 'foot-pedal',
       manufacturer_id: (rand(Manufacturer.frames.count) + 1),
       rear_tire_narrow: true,
@@ -65,12 +64,12 @@ task seed_dup_bikes: :environment do
   @user = User.find_by_email('user@example.com')
   @member = User.find_by_email('member@example.com')
   @org = Organization.first
-  @cycle_type_id = CycleType.find_by_name('Bike').id
+  @cycle_type = CycleType.new(:bike)
   @serial_number = (0...10).map { (65 + rand(26)).chr }.join
   @manufacturer_id = (rand(Manufacturer.frames.count) + 1)
   500.times do
     bike = Bike.new(
-      cycle_type_id: @cycle_type_id,
+      cycle_type: :bike,
       propulsion_type: 'foot-pedal',
       manufacturer_id: @manufacturer_id,
       rear_tire_narrow: true,


### PR DESCRIPTION
Seeding test users and bikes fails on master because `CycleType` was
refactored to no longer be an `ActiveRecord` model in 77479df97.

```
bike_index master % rake seed_test_users_and_bikes
. . .
Users added successfully
rake aborted!
NoMethodError: undefined method `find_by_name' for CycleType:Class
lib/tasks/seed_tasks.rake:33:in `block in <top (required)>'
ruby/2.5.1/bin/ruby_executable_hooks:24:in `eval'
ruby/2.5.1/bin/ruby_executable_hooks:24:in `<main>'
Tasks: TOP => seed_test_users_and_bikes
```

```
bike_index fix-cycletype-in-seeds % rake seed_test_users_and_bikes
Users added successfully
New bike made by FiberFix
New bike made by Trigger Point
. . .
Total items (including combinatorial categories):    26
Total items (including combinatorial categories):    2122
```